### PR TITLE
feature:OP-19353:added new Dockerfileubi8 for RHEL ubi8.7-minimal-changes

### DIFF
--- a/Dockerfile.ubi8-minimal
+++ b/Dockerfile.ubi8-minimal
@@ -1,0 +1,23 @@
+FROM alpine:3 AS build
+RUN apk add --update \
+    openjdk11 \
+    && rm -rf /var/cache/apk
+LABEL maintainer="sig-platform@spinnaker.io"
+ENV GRADLE_USER_HOME /workspace/.gradle
+ENV GRADLE_OPTS -Xmx4g
+WORKDIR /build
+COPY . /build
+RUN ./gradlew --no-daemon kayenta-web:installDist -x test
+
+
+FROM quay.io/opsmxpublic/image-base-java-ubi8-minimal:latest AS package
+LABEL maintainer="info@opsmx.io"
+
+RUN  microdnf install --setopt=tsflags=nodocs  openssh-clients  && \
+  groupadd -g 10111 spinnaker && \
+  useradd -g spinnaker -u 10111 spinnaker && \
+  mkdir -p /opt/kayenta/plugins && chown -R spinnaker:spinnaker /opt/kayenta/plugins
+
+COPY --from=build /build/kayenta-web/build/install/kayenta /opt/kayenta
+USER spinnaker
+CMD ["/opt/kayenta/bin/kayenta"]

--- a/Dockerfileubi8
+++ b/Dockerfileubi8
@@ -1,0 +1,17 @@
+#FROM alpine:3.16
+#LABEL maintainer="sig-platform@spinnaker.io"
+#RUN apk --no-cache add --update bash openjdk11-jre
+#RUN addgroup -S -g 10111 spinnaker
+#RUN adduser -S -G spinnaker -u 10111 spinnaker
+
+FROM quay.io/opsmxpublic/ubi8-jdk-11:v1
+LABEL maintainer="info@opsmx.io"
+
+RUN  microdnf install --setopt=tsflags=nodocs  openssh-clients  && \
+  groupadd -g 10111 spinnaker && \
+  useradd -g spinnaker -u 10111 spinnaker && \
+  mkdir -p /opt/kayenta/plugins && chown -R spinnaker:spinnaker /opt/kayenta/plugins
+
+COPY kayenta-web/build/install/kayenta /opt/kayenta
+USER spinnaker
+CMD ["/opt/kayenta/bin/kayenta"]


### PR DESCRIPTION
https://devopsmx.atlassian.net/browse/OP-19353
Changes done :

Copied Dockerfile.slim to Dockerfileubi8
Changed the base image from alpine to redhat
--- javabase file is committed at :
https://github.com/OpsMx/image-base-java/blob/main/Dockerfile
--- image is built and uploaded at:
http://quay.io/opsmxpublic/ubi8-jdk-11:v1

Added command to microdnf install required packages
Added group with group-id and added user with user-id
Changed ownership to plugins to the above spinnaker:spinnaker
Combined all RUN commands in single RUN command to avoid multiple layers