### PR TITLE
Fixed KayentaSerializationConfigurationProperties not found issue

### DIFF
--- a/kayenta-core/src/main/java/com/netflix/kayenta/canary/orca/CompareJudgeResultsTask.java
+++ b/kayenta-core/src/main/java/com/netflix/kayenta/canary/orca/CompareJudgeResultsTask.java
@@ -33,7 +33,6 @@ import java.util.Map;
 import javax.annotation.Nonnull;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Component;
 
 @Slf4j

--- a/kayenta-core/src/main/java/com/netflix/kayenta/config/KayentaConfiguration.java
+++ b/kayenta-core/src/main/java/com/netflix/kayenta/config/KayentaConfiguration.java
@@ -23,7 +23,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.google.common.collect.ImmutableList;
-import com.netflix.kayenta.config.KayentaSerializationConfigurationProperties;
+import com.netflix.kayenta.atlas.config.KayentaSerializationConfigurationProperties;
 import com.netflix.kayenta.canary.CanaryMetricSetQueryConfig;
 import com.netflix.kayenta.metrics.MapBackedMetricsServiceRepository;
 import com.netflix.kayenta.metrics.MetricSetMixerService;

--- a/kayenta-core/src/main/java/com/netflix/kayenta/config/KayentaSerializationConfigurationProperties.java
+++ b/kayenta-core/src/main/java/com/netflix/kayenta/config/KayentaSerializationConfigurationProperties.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.netflix.kayenta.config;
+package com.netflix.kayenta.atlas.config;
 
 import lombok.Data;
 

--- a/kayenta-core/src/main/java/com/netflix/kayenta/retrofit/config/RetrofitClientConfiguration.java
+++ b/kayenta-core/src/main/java/com/netflix/kayenta/retrofit/config/RetrofitClientConfiguration.java
@@ -17,7 +17,7 @@
 package com.netflix.kayenta.retrofit.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.netflix.kayenta.config.KayentaSerializationConfigurationProperties;
+import com.netflix.kayenta.atlas.config.KayentaSerializationConfigurationProperties;
 import com.netflix.kayenta.config.KayentaConfiguration;
 import com.netflix.spinnaker.config.OkHttpClientConfiguration;
 import com.netflix.spinnaker.orca.retrofit.exceptions.RetrofitExceptionHandler;


### PR DESCRIPTION
KayentaSerializationConfigurationProperties is not found in many classes due to wrong import statements