### PR TITLE
Fixed Configuration issue

### DIFF
--- a/kayenta-integration-tests/src/test/java/com/netflix/kayenta/tests/BaseIntegrationTest.java
+++ b/kayenta-integration-tests/src/test/java/com/netflix/kayenta/tests/BaseIntegrationTest.java
@@ -17,14 +17,19 @@ package com.netflix.kayenta.tests;
 
 import com.netflix.kayenta.Main;
 import com.netflix.kayenta.configuration.MetricsReportingConfiguration;
+import com.netflix.kayenta.prometheus.config.PrometheusConfiguration;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.actuate.observability.AutoConfigureObservability;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
 @AutoConfigureObservability
+@ImportAutoConfiguration(PrometheusConfiguration.class)
+@ComponentScan(basePackages = "com.netflix.kayenta.standalonecanaryanalysis")
 @SpringBootTest(
     classes = {MetricsReportingConfiguration.class, Main.class},
     webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT,


### PR DESCRIPTION
there is a change in annotation from @AutoConfigureMetrics to  @AutoConfigureObservability as the former is deprecated since Springboot 3.0.0.
But with @AutoConfigureObservability,  the beans defined in the PrometheusConfiguration are not getting created hence the test response body doesn't have prometheus content in it for those tests that need prometheus.
After importing the config using the following annotation on BaseIntegrationTest the tests are passing.
@ImportAutoConfiguration(PrometheusConfiguration.class)

Similarily, by adding basepackage=standalonecanaryanalysis, it is able to fetch required beans