### PR TITLE
fix(sql): changes for SpringBoot3 and Spring Data 3.0 compatibility

### DIFF
--- a/kayenta-sql/src/main/java/com/netflix/kayenta/sql/storage/model/SqlBaseObject.java
+++ b/kayenta-sql/src/main/java/com/netflix/kayenta/sql/storage/model/SqlBaseObject.java
@@ -16,9 +16,9 @@
 
 package com.netflix.kayenta.sql.storage.model;
 
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
 import java.time.Instant;
-import javax.persistence.Entity;
-import javax.persistence.Id;
 import lombok.Data;
 
 @Data

--- a/kayenta-sql/src/main/java/com/netflix/kayenta/sql/storage/model/SqlCanaryArchive.java
+++ b/kayenta-sql/src/main/java/com/netflix/kayenta/sql/storage/model/SqlCanaryArchive.java
@@ -16,8 +16,8 @@
 
 package com.netflix.kayenta.sql.storage.model;
 
-import javax.persistence.Entity;
-import javax.persistence.Table;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
 
 @Entity
 @Table(name = "canary_archive")

--- a/kayenta-sql/src/main/java/com/netflix/kayenta/sql/storage/model/SqlCanaryConfig.java
+++ b/kayenta-sql/src/main/java/com/netflix/kayenta/sql/storage/model/SqlCanaryConfig.java
@@ -16,8 +16,8 @@
 
 package com.netflix.kayenta.sql.storage.model;
 
-import javax.persistence.Entity;
-import javax.persistence.Table;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
 
 @Entity
 @Table(name = "canary_config")

--- a/kayenta-sql/src/main/java/com/netflix/kayenta/sql/storage/model/SqlMetricSetPairs.java
+++ b/kayenta-sql/src/main/java/com/netflix/kayenta/sql/storage/model/SqlMetricSetPairs.java
@@ -16,8 +16,8 @@
 
 package com.netflix.kayenta.sql.storage.model;
 
-import javax.persistence.Entity;
-import javax.persistence.Table;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
 
 @Entity
 @Table(name = "metric_set_pairs")

--- a/kayenta-sql/src/main/java/com/netflix/kayenta/sql/storage/model/SqlMetricSets.java
+++ b/kayenta-sql/src/main/java/com/netflix/kayenta/sql/storage/model/SqlMetricSets.java
@@ -16,8 +16,8 @@
 
 package com.netflix.kayenta.sql.storage.model;
 
-import javax.persistence.Entity;
-import javax.persistence.Table;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
 
 @Entity
 @Table(name = "metric_sets")

--- a/kayenta-sql/src/main/java/com/netflix/kayenta/sql/storage/repo/SqlCanaryArchiveRepo.java
+++ b/kayenta-sql/src/main/java/com/netflix/kayenta/sql/storage/repo/SqlCanaryArchiveRepo.java
@@ -17,7 +17,9 @@
 package com.netflix.kayenta.sql.storage.repo;
 
 import com.netflix.kayenta.sql.storage.model.SqlCanaryArchive;
+import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.PagingAndSortingRepository;
 
 public interface SqlCanaryArchiveRepo
-    extends PagingAndSortingRepository<SqlCanaryArchive, String> {}
+    extends PagingAndSortingRepository<SqlCanaryArchive, String>,
+        CrudRepository<SqlCanaryArchive, String> {}

--- a/kayenta-sql/src/main/java/com/netflix/kayenta/sql/storage/repo/SqlCanaryConfigRepo.java
+++ b/kayenta-sql/src/main/java/com/netflix/kayenta/sql/storage/repo/SqlCanaryConfigRepo.java
@@ -17,6 +17,9 @@
 package com.netflix.kayenta.sql.storage.repo;
 
 import com.netflix.kayenta.sql.storage.model.SqlCanaryConfig;
+import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.PagingAndSortingRepository;
 
-public interface SqlCanaryConfigRepo extends PagingAndSortingRepository<SqlCanaryConfig, String> {}
+public interface SqlCanaryConfigRepo
+    extends PagingAndSortingRepository<SqlCanaryConfig, String>,
+        CrudRepository<SqlCanaryConfig, String> {}

--- a/kayenta-sql/src/main/java/com/netflix/kayenta/sql/storage/repo/SqlMetricSetPairsRepo.java
+++ b/kayenta-sql/src/main/java/com/netflix/kayenta/sql/storage/repo/SqlMetricSetPairsRepo.java
@@ -17,7 +17,9 @@
 package com.netflix.kayenta.sql.storage.repo;
 
 import com.netflix.kayenta.sql.storage.model.SqlMetricSetPairs;
+import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.PagingAndSortingRepository;
 
 public interface SqlMetricSetPairsRepo
-    extends PagingAndSortingRepository<SqlMetricSetPairs, String> {}
+    extends PagingAndSortingRepository<SqlMetricSetPairs, String>,
+        CrudRepository<SqlMetricSetPairs, String> {}

--- a/kayenta-sql/src/main/java/com/netflix/kayenta/sql/storage/repo/SqlMetricSetsRepo.java
+++ b/kayenta-sql/src/main/java/com/netflix/kayenta/sql/storage/repo/SqlMetricSetsRepo.java
@@ -17,6 +17,9 @@
 package com.netflix.kayenta.sql.storage.repo;
 
 import com.netflix.kayenta.sql.storage.model.SqlMetricSets;
+import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.PagingAndSortingRepository;
 
-public interface SqlMetricSetsRepo extends PagingAndSortingRepository<SqlMetricSets, String> {}
+public interface SqlMetricSetsRepo
+    extends PagingAndSortingRepository<SqlMetricSets, String>,
+        CrudRepository<SqlMetricSets, String> {}


### PR DESCRIPTION
Added  changes to fix the build issue in kayenta-sql for SpringBoot3 and Java17 compatibility: 
* Change javax > jakarta in the persistence api's
* Explicitly combine CrudRepository with PagingAndSortingRepository interface. 
              This is because Spring Data 3.0 has separated the sorting repositories from the base ones and PagingAndSortingRepository and other interfaces don't extend CrudRepository anymore.  