### PR TITLE
Junit4 to Junit5 Code Changes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,12 @@ subprojects { project ->
     test {
       testLogging {
         exceptionFormat = "full"
+        afterSuite { desc, result ->
+          if (!desc.parent) {
+            println "Results: ${result.resultType} (${result.testCount} tests, ${result.successfulTestCount} successes, ${result.failedTestCount} failures, ${result.skippedTestCount} skipped)"
+            println "Report file: ${reports.html.entryPoint}"
+          }
+        }
       }
       minHeapSize = "512m"
       maxHeapSize = "512m"
@@ -119,7 +125,6 @@ subprojects { project ->
       testImplementation "org.hamcrest:hamcrest-core"
       //testImplementation "org.apache.groovy:groovy-all"
       testRuntimeOnly "cglib:cglib-nodep"
-      testRuntimeOnly "org.junit.vintage:junit-vintage-engine"
       testRuntimeOnly "org.objenesis:objenesis"
     }
   }

--- a/kayenta-atlas/kayenta-atlas.gradle
+++ b/kayenta-atlas/kayenta-atlas.gradle
@@ -9,3 +9,6 @@ dependencies {
 
   api "org.apache.commons:commons-io:1.3.2"
 }
+test {
+  useJUnitPlatform()
+}

--- a/kayenta-atlas/src/test/java/com/netflix/kayenta/atlas/BackendTest.java
+++ b/kayenta-atlas/src/test/java/com/netflix/kayenta/atlas/BackendTest.java
@@ -6,7 +6,7 @@ import com.netflix.kayenta.atlas.model.Backend;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class BackendTest {
   @Test

--- a/kayenta-atlas/src/test/java/com/netflix/kayenta/atlas/BackendsTest.java
+++ b/kayenta-atlas/src/test/java/com/netflix/kayenta/atlas/BackendsTest.java
@@ -12,21 +12,21 @@ import java.io.InputStream;
 import java.util.List;
 import java.util.Optional;
 import org.apache.commons.io.IOUtils;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 @Configuration
 @ComponentScan({"com.netflix.kayenta.retrofit.config"})
 class BackendsConfig {}
 
-@RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(classes = {BackendsConfig.class})
+@ExtendWith(SpringExtension.class)
 public class BackendsTest {
   @Autowired private ResourceLoader resourceLoader;
 

--- a/kayenta-atlas/src/test/java/com/netflix/kayenta/atlas/IntegrationTest.java
+++ b/kayenta-atlas/src/test/java/com/netflix/kayenta/atlas/IntegrationTest.java
@@ -19,14 +19,14 @@ import java.util.stream.Collectors;
 import javax.validation.constraints.NotNull;
 import lombok.*;
 import org.apache.commons.io.IOUtils;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 @Configuration
 @ComponentScan({"com.netflix.kayenta.retrofit.config"})
@@ -43,8 +43,8 @@ class CanaryMetricConfigWithResults {
   @NotNull @Getter private List<AtlasResults> atlasResults;
 }
 
-@RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(classes = {TestConfig.class})
+@ExtendWith(SpringExtension.class)
 public class IntegrationTest {
 
   @Autowired private ResourceLoader resourceLoader;

--- a/kayenta-atlas/src/test/java/com/netflix/kayenta/atlas/config/AtlasSSEConverterTest.java
+++ b/kayenta-atlas/src/test/java/com/netflix/kayenta/atlas/config/AtlasSSEConverterTest.java
@@ -1,7 +1,5 @@
 package com.netflix.kayenta.atlas.config;
 
-import static org.junit.Assert.*;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.kayenta.atlas.model.AtlasResults;
 import com.netflix.kayenta.metrics.FatalQueryException;
@@ -9,7 +7,8 @@ import com.netflix.kayenta.metrics.RetryableQueryException;
 import java.io.BufferedReader;
 import java.io.StringReader;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class AtlasSSEConverterTest {
 
@@ -30,27 +29,39 @@ public class AtlasSSEConverterTest {
   @Test
   public void loneClose() {
     List<AtlasResults> results = atlasResultsFromSSE(closeMessage);
-    assertEquals(1, results.size());
+    Assertions.assertEquals(1, results.size());
   }
 
   @Test
   public void dataPlusClose() {
     List<AtlasResults> results = atlasResultsFromSSE(timeseriesMessage + closeMessage);
-    assertEquals(2, results.size());
+    Assertions.assertEquals(2, results.size());
   }
 
-  @Test(expected = RetryableQueryException.class)
+  @Test
   public void missingCloseThrows() {
-    atlasResultsFromSSE(timeseriesMessage);
+    Assertions.assertThrows(
+        RetryableQueryException.class,
+        () -> {
+          atlasResultsFromSSE(timeseriesMessage);
+        });
   }
 
-  @Test(expected = FatalQueryException.class)
+  @Test
   public void fatalErrorWithoutClose() {
-    atlasResultsFromSSE(errorMessageIllegalStateMessage);
+    Assertions.assertThrows(
+        FatalQueryException.class,
+        () -> {
+          atlasResultsFromSSE(errorMessageIllegalStateMessage);
+        });
   }
 
-  @Test(expected = RetryableQueryException.class)
+  @Test
   public void retryableErrorWithoutClose() {
-    atlasResultsFromSSE(retryableErrorMessage);
+    Assertions.assertThrows(
+        RetryableQueryException.class,
+        () -> {
+          atlasResultsFromSSE(retryableErrorMessage);
+        });
   }
 }

--- a/kayenta-blobs/kayenta-blobs.gradle
+++ b/kayenta-blobs/kayenta-blobs.gradle
@@ -6,3 +6,6 @@ dependencies {
     testImplementation group: 'org.mockito', name: 'mockito-core', version: '1.9.10'
     testImplementation group: 'com.tngtech.java', name: 'junit-dataprovider', version: '1.13.1'
 }
+test {
+    useJUnitPlatform()
+}

--- a/kayenta-blobs/src/test/java/com/netflix/kayenta/blobs/storage/TestableBlobsStorageServiceTest.java
+++ b/kayenta-blobs/src/test/java/com/netflix/kayenta/blobs/storage/TestableBlobsStorageServiceTest.java
@@ -31,14 +31,13 @@ import com.netflix.spinnaker.kork.web.exceptions.NotFoundException;
 import com.tngtech.java.junit.dataprovider.*;
 import java.util.*;
 import lombok.extern.slf4j.Slf4j;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.*;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mockito;
 
-@RunWith(DataProviderRunner.class)
 @Slf4j
 public class TestableBlobsStorageServiceTest {
 
@@ -48,7 +47,7 @@ public class TestableBlobsStorageServiceTest {
   private AccountCredentialsRepository credentialsRepository;
   private CanaryConfigIndex mockedCanaryConfigIndex;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     List<String> testAccountNames =
         Arrays.asList("AzDev_Testing_Account_1", "AzDev_Testing_Account_2");
@@ -76,18 +75,18 @@ public class TestableBlobsStorageServiceTest {
             testAccountNames, kayentaObjectMapper, credentialsRepository, mockedCanaryConfigIndex);
   }
 
-  @After
+  @AfterEach
   public void tearDown() {}
 
-  @Test
-  @UseDataProvider("servicesAccountDataset")
+  @ParameterizedTest
+  @MethodSource("servicesAccountDataset")
   public void servicesAccount(String accountName, boolean expected) {
     log.info(String.format("Running servicesAccountTest(%s)", accountName));
-    Assert.assertEquals(expected, testBlobsStorageService.servicesAccount(accountName));
+    Assertions.assertEquals(expected, testBlobsStorageService.servicesAccount(accountName));
   }
 
-  @Test
-  @UseDataProvider("loadObjectDataset")
+  @ParameterizedTest
+  @MethodSource("loadObjectDataset")
   public void loadObject(
       String accountName,
       ObjectType objectType,
@@ -104,24 +103,24 @@ public class TestableBlobsStorageServiceTest {
 
       CanaryConfig result =
           testBlobsStorageService.loadObject(accountName, objectType, testItemKey);
-      Assert.assertEquals(applications.get(0), result.getApplications().get(0));
+      Assertions.assertEquals(applications.get(0), result.getApplications().get(0));
     } catch (IllegalArgumentException e) {
-      Assert.assertEquals("Unable to resolve account " + accountName + ".", e.getMessage());
+      Assertions.assertEquals("Unable to resolve account " + accountName + ".", e.getMessage());
     } catch (NotFoundException e) {
-      Assert.assertEquals(
+      Assertions.assertEquals(
           "Could not fetch items from Azure Cloud Storage: Item not found at "
               + rootFolder
               + "/canary_config/"
               + testItemKey,
           e.getMessage());
     } catch (IllegalStateException e) {
-      Assert.assertEquals(
+      Assertions.assertEquals(
           "Unable to deserialize object (key: " + testItemKey + ")", e.getMessage());
     }
   }
 
-  @Test
-  @UseDataProvider("storeObjectDataset")
+  @ParameterizedTest
+  @MethodSource("storeObjectDataset")
   public void storeObject(
       String accountName,
       ObjectType objectType,
@@ -147,14 +146,14 @@ public class TestableBlobsStorageServiceTest {
       testBlobsStorageService.storeObject(
           accountName, objectType, testItemKey, canaryConfig, fakeFileName, isAnUpdate);
       HashMap<String, String> result = testBlobsStorageService.blobStored;
-      Assert.assertEquals(fakeBlobName, result.get("blob"));
+      Assertions.assertEquals(fakeBlobName, result.get("blob"));
     } catch (IllegalArgumentException e) {
-      Assert.assertEquals("Unable to resolve account " + accountName + ".", e.getMessage());
+      Assertions.assertEquals("Unable to resolve account " + accountName + ".", e.getMessage());
     }
   }
 
-  @Test
-  @UseDataProvider("deleteObjectDataset")
+  @ParameterizedTest
+  @MethodSource("deleteObjectDataset")
   public void deleteObject(String accountName, ObjectType objectType, String testItemKey) {
 
     String fakeBlobName =
@@ -177,14 +176,15 @@ public class TestableBlobsStorageServiceTest {
           "Running deleteObjectTest for rootFolder/" + objectType.getGroup() + "/" + testItemKey);
       testBlobsStorageService.deleteObject(accountName, objectType, testItemKey);
       HashMap<String, String> result = testBlobsStorageService.blobStored;
-      Assert.assertEquals("invoked", result.get(String.format("deleteIfexists(%s)", fakeBlobName)));
+      Assertions.assertEquals(
+          "invoked", result.get(String.format("deleteIfexists(%s)", fakeBlobName)));
     } catch (IllegalArgumentException e) {
-      Assert.assertEquals("Unable to resolve account " + accountName + ".", e.getMessage());
+      Assertions.assertEquals("Unable to resolve account " + accountName + ".", e.getMessage());
     }
   }
 
-  @Test
-  @UseDataProvider("listObjectKeysDataset")
+  @ParameterizedTest
+  @MethodSource("listObjectKeysDataset")
   public void listObjectKeys(
       String accountName, ObjectType objectType, List<String> applications, boolean skipIndex) {
 
@@ -193,16 +193,15 @@ public class TestableBlobsStorageServiceTest {
       List<Map<String, Object>> result =
           testBlobsStorageService.listObjectKeys(accountName, objectType, applications, skipIndex);
       if (objectType == ObjectType.CANARY_CONFIG) {
-        Assert.assertEquals("canary_test", result.get(0).get("name"));
+        Assertions.assertEquals("canary_test", result.get(0).get("name"));
       } else {
-        Assert.assertEquals(6, result.size());
+        Assertions.assertEquals(6, result.size());
       }
     } catch (IllegalArgumentException e) {
-      Assert.assertEquals("Unable to resolve account " + accountName + ".", e.getMessage());
+      Assertions.assertEquals("Unable to resolve account " + accountName + ".", e.getMessage());
     }
   }
 
-  @DataProvider
   public static Object[][] servicesAccountDataset() {
     return new Object[][] {
       {"AzDev_Testing_Account_1", true},
@@ -212,7 +211,6 @@ public class TestableBlobsStorageServiceTest {
     };
   }
 
-  @DataProvider
   public static Object[][] loadObjectDataset() {
     return new Object[][] {
       {
@@ -260,7 +258,6 @@ public class TestableBlobsStorageServiceTest {
     };
   }
 
-  @DataProvider
   public static Object[][] storeObjectDataset() {
     return new Object[][] {
       {"Kayenta_Account_1", ObjectType.CANARY_CONFIG, "Test_Canary", "Test_App", false},
@@ -271,7 +268,6 @@ public class TestableBlobsStorageServiceTest {
     };
   }
 
-  @DataProvider
   public static Object[][] deleteObjectDataset() {
     return new Object[][] {
       {"Kayenta_Account_1", ObjectType.CANARY_CONFIG, "some(GUID)"},
@@ -282,7 +278,6 @@ public class TestableBlobsStorageServiceTest {
     };
   }
 
-  @DataProvider
   public static Object[][] listObjectKeysDataset() {
     return new Object[][] {
       {"Kayenta_Account_1", ObjectType.CANARY_CONFIG, Collections.singletonList("Test_App"), true},

--- a/kayenta-core/kayenta-core.gradle
+++ b/kayenta-core/kayenta-core.gradle
@@ -25,5 +25,7 @@ dependencies {
   api "javax.validation:validation-api:+"
 
   testImplementation "io.spinnaker.kork:kork-jedis-test"
-  //testImplementation "org.apache.groovy:groovy-all:+"
+}
+test {
+  useJUnitPlatform()
 }

--- a/kayenta-core/src/test/groovy/com/netflix/kayenta/canary/providers/metrics/QueryConfigUtilsTest.java
+++ b/kayenta-core/src/test/groovy/com/netflix/kayenta/canary/providers/metrics/QueryConfigUtilsTest.java
@@ -24,7 +24,7 @@ import static org.mockito.Mockito.when;
 import com.netflix.kayenta.canary.CanaryConfig;
 import com.netflix.kayenta.canary.CanaryMetricSetQueryConfig;
 import com.netflix.kayenta.canary.CanaryScope;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class QueryConfigUtilsTest {
 

--- a/kayenta-core/src/test/groovy/com/netflix/kayenta/metrics/SynchronousQueryProcessorTest.java
+++ b/kayenta-core/src/test/groovy/com/netflix/kayenta/metrics/SynchronousQueryProcessorTest.java
@@ -27,6 +27,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.openMocks;
 import static org.springframework.http.HttpStatus.BAD_GATEWAY;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
@@ -45,8 +46,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -75,8 +76,9 @@ public class SynchronousQueryProcessorTest {
 
   @InjectMocks SynchronousQueryProcessor processor;
 
-  @Before
+  @BeforeEach
   public void setUp() {
+    openMocks(this);
     when(metricsServiceRepository.getRequiredOne(METRICS)).thenReturn(metricsService);
     when(storageServiceRepository.getRequiredOne(STORAGE)).thenReturn(storageService);
     when(retryConfiguration.getAttempts()).thenReturn(ATTEMPTS);

--- a/kayenta-core/src/test/groovy/com/netflix/kayenta/security/MapBackedAccountCredentialsRepositoryTest.java
+++ b/kayenta-core/src/test/groovy/com/netflix/kayenta/security/MapBackedAccountCredentialsRepositoryTest.java
@@ -26,7 +26,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class MapBackedAccountCredentialsRepositoryTest {
 

--- a/kayenta-core/src/test/groovy/com/netflix/kayenta/storage/MapBackedStorageServiceRepositoryTest.java
+++ b/kayenta-core/src/test/groovy/com/netflix/kayenta/storage/MapBackedStorageServiceRepositoryTest.java
@@ -23,7 +23,7 @@ import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class MapBackedStorageServiceRepositoryTest {
 

--- a/kayenta-datadog/kayenta-datadog.gradle
+++ b/kayenta-datadog/kayenta-datadog.gradle
@@ -4,3 +4,6 @@ dependencies {
   testImplementation group: 'junit', name: 'junit'
   testImplementation group: 'org.mock-server', name: 'mockserver-junit-rule', version: '5.10.0'
 }
+test {
+  useJUnitPlatform()
+}

--- a/kayenta-datadog/src/test/java/com/netflix/kayenta/datadog/functional/DatadogSecretsDoNotLeakWhenApiCalledFunctionalTest.java
+++ b/kayenta-datadog/src/test/java/com/netflix/kayenta/datadog/functional/DatadogSecretsDoNotLeakWhenApiCalledFunctionalTest.java
@@ -38,9 +38,9 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.junit.Before;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockserver.client.MockServerClient;
 import org.mockserver.junit.MockServerRule;
 import org.mockserver.model.HttpRequest;
@@ -63,7 +63,7 @@ public class DatadogSecretsDoNotLeakWhenApiCalledFunctionalTest {
 
   DatadogRemoteService datadogRemoteService;
 
-  @Before
+  @BeforeEach
   public void before() {
     listAppender = new ListAppender<>();
     Logger mockLogger =

--- a/kayenta-datadog/src/test/java/com/netflix/kayenta/datadog/service/DatadogTimeSeriesTest.java
+++ b/kayenta-datadog/src/test/java/com/netflix/kayenta/datadog/service/DatadogTimeSeriesTest.java
@@ -22,7 +22,7 @@ import static org.junit.Assert.assertEquals;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class DatadogTimeSeriesTest {
 

--- a/kayenta-graphite/src/integration-test/java/com/netflix/kayenta/graphite/E2EIntegrationTest.java
+++ b/kayenta-graphite/src/integration-test/java/com/netflix/kayenta/graphite/E2EIntegrationTest.java
@@ -38,14 +38,14 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.time.Instant;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.web.server.LocalServerPort;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = Main.class)
 public class E2EIntegrationTest {
 

--- a/kayenta-graphite/src/test/java/com/netflix/kayenta/graphite/IntegrationTest.java
+++ b/kayenta-graphite/src/test/java/com/netflix/kayenta/graphite/IntegrationTest.java
@@ -43,14 +43,14 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 import org.apache.commons.io.IOUtils;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 @Configuration
 @ComponentScan({"com.netflix.kayenta.retrofit.config"})
@@ -67,7 +67,7 @@ class CanaryMetricConfigWithResults {
   @NotNull @Getter private List<GraphiteResults> graphiteResults;
 }
 
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = {TestConfig.class})
 public class IntegrationTest {
 

--- a/kayenta-influxdb/kayenta-influxdb.gradle
+++ b/kayenta-influxdb/kayenta-influxdb.gradle
@@ -1,3 +1,6 @@
 dependencies {
   implementation project(":kayenta-core")
 }
+test {
+  useJUnitPlatform()
+}

--- a/kayenta-influxdb/src/test/java/com/netflix/kayenta/influxdb/config/InfluxDbResponseConverterTest.java
+++ b/kayenta-influxdb/src/test/java/com/netflix/kayenta/influxdb/config/InfluxDbResponseConverterTest.java
@@ -19,13 +19,14 @@ package com.netflix.kayenta.influxdb.config;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertThrows;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.kayenta.influxdb.model.InfluxDbResult;
 import java.io.ByteArrayOutputStream;
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import retrofit.converter.ConversionException;
 import retrofit.mime.TypedByteArray;
 import retrofit.mime.TypedInput;
@@ -107,10 +108,11 @@ public class InfluxDbResponseConverterTest {
     assertThat(result, is(results));
   }
 
-  @Test(expected = ConversionException.class)
+  @Test
   public void deserializeWrongValue() throws Exception {
     TypedInput input = new TypedByteArray(MIME_TYPE, "{\"foo\":\"bar\"}".getBytes());
-    influxDbResponseConverter.fromBody(input, List.class);
+    assertThrows(
+        ConversionException.class, () -> influxDbResponseConverter.fromBody(input, List.class));
   }
 
   private String asString(TypedOutput typedOutput) throws Exception {

--- a/kayenta-influxdb/src/test/java/com/netflix/kayenta/influxdb/service/InfluxdbQueryBuilderTest.java
+++ b/kayenta-influxdb/src/test/java/com/netflix/kayenta/influxdb/service/InfluxdbQueryBuilderTest.java
@@ -18,6 +18,7 @@ package com.netflix.kayenta.influxdb.service;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertThrows;
 
 import com.netflix.kayenta.canary.providers.metrics.InfluxdbCanaryMetricSetQueryConfig;
 import com.netflix.kayenta.influxdb.canary.InfluxDbCanaryScope;
@@ -25,7 +26,7 @@ import com.netflix.kayenta.influxdb.metrics.InfluxDbQueryBuilder;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class InfluxdbQueryBuilderTest {
 
@@ -58,14 +59,15 @@ public class InfluxdbQueryBuilderTest {
     return fields;
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testBuild_withInvalidScope() {
     String measurement = "temperature";
 
     InfluxDbCanaryScope canaryScope = createScope();
     canaryScope.setScope("server='myapp-prod-v002'");
     InfluxdbCanaryMetricSetQueryConfig queryConfig = queryConfig(measurement, fieldsList(), null);
-    queryBuilder.build(queryConfig, canaryScope);
+    assertThrows(
+        IllegalArgumentException.class, () -> queryBuilder.build(queryConfig, canaryScope));
   }
 
   @Test
@@ -107,7 +109,7 @@ public class InfluxdbQueryBuilderTest {
             "SELECT *::field FROM temperature WHERE time >= '2010-01-01T12:00:00Z' AND time < '2010-01-01T12:01:40Z' AND server = 'myapp-prod-v002'"));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testBuild_customInlineTemplateWithMissingRequiredVariables() {
     // missing required variables are: {scope} and {timeFilter}
     String inLineQuery = "SELECT count FROM measurement";
@@ -115,7 +117,8 @@ public class InfluxdbQueryBuilderTest {
     InfluxDbCanaryScope canaryScope = createScope();
     canaryScope.setScope("server:myapp-prod-v002");
     InfluxdbCanaryMetricSetQueryConfig queryConfig = queryConfig(null, null, inLineQuery);
-    queryBuilder.build(queryConfig, canaryScope);
+    assertThrows(
+        IllegalArgumentException.class, () -> queryBuilder.build(queryConfig, canaryScope));
   }
 
   @Test
@@ -133,7 +136,7 @@ public class InfluxdbQueryBuilderTest {
             "SELECT count FROM measurement WHERE label1 = 'value1' AND time >= '2010-01-01T12:00:00Z' AND time < '2010-01-01T12:01:40Z' AND server = 'myapp-prod-v002'"));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testBuild_customInlineTemplateWithInvalidAdditionalQuery() {
     String inLineQuery =
         "SELECT sum(count) FROM web_requests WHERE $\\{scope} AND $\\{timeFilter} GROUP BY time(1m); DROP DATABASE metrics";
@@ -141,10 +144,11 @@ public class InfluxdbQueryBuilderTest {
     InfluxDbCanaryScope canaryScope = createScope();
     canaryScope.setScope("server:myapp-prod-v002");
     InfluxdbCanaryMetricSetQueryConfig queryConfig = queryConfig(null, null, inLineQuery);
-    queryBuilder.build(queryConfig, canaryScope);
+    assertThrows(
+        IllegalArgumentException.class, () -> queryBuilder.build(queryConfig, canaryScope));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testBuild_customInlineTemplateWithInvalidQueryType() {
     String inLineQuery =
         "SELECT sum(count) FROM web_requests WHERE $\\{scope} AND $\\{timeFilter} GROUP BY time(1m); SHOW SERIES";
@@ -152,10 +156,11 @@ public class InfluxdbQueryBuilderTest {
     InfluxDbCanaryScope canaryScope = createScope();
     canaryScope.setScope("server:myapp-prod-v002");
     InfluxdbCanaryMetricSetQueryConfig queryConfig = queryConfig(null, null, inLineQuery);
-    queryBuilder.build(queryConfig, canaryScope);
+    assertThrows(
+        IllegalArgumentException.class, () -> queryBuilder.build(queryConfig, canaryScope));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testBuild_customInlineTemplateWithInvalidLineComments() {
     String inLineQuery =
         "'SELECT count FROM web_requests WHERE $\\{scope} AND $\\{timeFilter}' or 1=1--";
@@ -163,6 +168,7 @@ public class InfluxdbQueryBuilderTest {
     InfluxDbCanaryScope canaryScope = createScope();
     canaryScope.setScope("server:myapp-prod-v002");
     InfluxdbCanaryMetricSetQueryConfig queryConfig = queryConfig(null, null, inLineQuery);
-    queryBuilder.build(queryConfig, canaryScope);
+    assertThrows(
+        IllegalArgumentException.class, () -> queryBuilder.build(queryConfig, canaryScope));
   }
 }

--- a/kayenta-integration-tests/kayenta-integration-tests.gradle
+++ b/kayenta-integration-tests/kayenta-integration-tests.gradle
@@ -16,6 +16,10 @@ test.testLogging {
     showStandardStreams = true
 }
 
+test {
+    useJUnitPlatform()
+}
+
 gradle.taskGraph.whenReady {
     tasks.test.enabled = (
       properties.getOrDefault('DISABLE_INTEGRATION_TESTS', 'false') != 'true'

--- a/kayenta-integration-tests/src/test/java/com/netflix/kayenta/tests/BaseIntegrationTest.java
+++ b/kayenta-integration-tests/src/test/java/com/netflix/kayenta/tests/BaseIntegrationTest.java
@@ -18,14 +18,14 @@ package com.netflix.kayenta.tests;
 import com.netflix.kayenta.Main;
 import com.netflix.kayenta.configuration.MetricsReportingConfiguration;
 import com.netflix.kayenta.prometheus.config.PrometheusConfiguration;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.actuate.observability.AutoConfigureObservability;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 @AutoConfigureObservability
 @ImportAutoConfiguration(PrometheusConfiguration.class)
@@ -34,7 +34,7 @@ import org.springframework.test.context.junit4.SpringRunner;
     classes = {MetricsReportingConfiguration.class, Main.class},
     webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT,
     value = "spring.application.name=kayenta")
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @ActiveProfiles({"base", "prometheus", "graphite", "cases"})
 public abstract class BaseIntegrationTest {
 

--- a/kayenta-integration-tests/src/test/java/com/netflix/kayenta/tests/ManagementTest.java
+++ b/kayenta-integration-tests/src/test/java/com/netflix/kayenta/tests/ManagementTest.java
@@ -19,7 +19,7 @@ import static com.netflix.kayenta.utils.AwaitilityUtils.awaitThirtySecondsUntil;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.is;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 

--- a/kayenta-integration-tests/src/test/java/com/netflix/kayenta/tests/SwaggerTest.java
+++ b/kayenta-integration-tests/src/test/java/com/netflix/kayenta/tests/SwaggerTest.java
@@ -16,7 +16,7 @@
 package com.netflix.kayenta.tests;
 
 import io.restassured.RestAssured;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 
 public class SwaggerTest extends BaseIntegrationTest {

--- a/kayenta-integration-tests/src/test/java/com/netflix/kayenta/tests/standalone/GraphiteStandaloneCanaryAnalysisTest.java
+++ b/kayenta-integration-tests/src/test/java/com/netflix/kayenta/tests/standalone/GraphiteStandaloneCanaryAnalysisTest.java
@@ -20,7 +20,7 @@ import static org.hamcrest.CoreMatchers.is;
 import com.netflix.kayenta.steps.StandaloneCanaryAnalysisSteps;
 import com.netflix.kayenta.tests.BaseIntegrationTest;
 import io.restassured.response.ValidatableResponse;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 public class GraphiteStandaloneCanaryAnalysisTest extends BaseIntegrationTest {

--- a/kayenta-integration-tests/src/test/java/com/netflix/kayenta/tests/standalone/PrometheusStandaloneCanaryAnalysisTest.java
+++ b/kayenta-integration-tests/src/test/java/com/netflix/kayenta/tests/standalone/PrometheusStandaloneCanaryAnalysisTest.java
@@ -20,7 +20,7 @@ import static org.hamcrest.CoreMatchers.is;
 import com.netflix.kayenta.steps.StandaloneCanaryAnalysisSteps;
 import com.netflix.kayenta.tests.BaseIntegrationTest;
 import io.restassured.response.ValidatableResponse;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 public class PrometheusStandaloneCanaryAnalysisTest extends BaseIntegrationTest {

--- a/kayenta-newrelic-insights/kayenta-newrelic-insights.gradle
+++ b/kayenta-newrelic-insights/kayenta-newrelic-insights.gradle
@@ -1,3 +1,6 @@
 dependencies {
   implementation project(":kayenta-core")
 }
+test {
+  useJUnitPlatform()
+}

--- a/kayenta-orca/kayenta-orca.gradle
+++ b/kayenta-orca/kayenta-orca.gradle
@@ -10,5 +10,5 @@ dependencies {
   // TODO(duftler): Move these to spinnaker-dependencies.
   testImplementation "io.spinnaker.orca:orca-test"
 
-  testImplementation "com.natpryce:hamkrest"
+  testImplementation "com.natpryce:hamkrest:+"
 }

--- a/kayenta-prometheus/kayenta-prometheus.gradle
+++ b/kayenta-prometheus/kayenta-prometheus.gradle
@@ -3,3 +3,6 @@ dependencies {
 
   testImplementation 'org.mock-server:mockserver-junit-rule:5.11.1'
 }
+test {
+  useJUnitPlatform()
+}

--- a/kayenta-prometheus/src/test/java/com/netflix/kayenta/prometheus/config/PrometheusHealthConfigurationTest.java
+++ b/kayenta-prometheus/src/test/java/com/netflix/kayenta/prometheus/config/PrometheusHealthConfigurationTest.java
@@ -21,7 +21,7 @@ import static org.mockito.Mockito.mock;
 
 import com.netflix.kayenta.metrics.MetricsService;
 import com.netflix.kayenta.security.AccountCredentialsRepository;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.boot.actuate.health.HealthIndicator;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;

--- a/kayenta-prometheus/src/test/java/com/netflix/kayenta/prometheus/health/PrometheusHealthIndicatorTest.java
+++ b/kayenta-prometheus/src/test/java/com/netflix/kayenta/prometheus/health/PrometheusHealthIndicatorTest.java
@@ -22,19 +22,26 @@ import static org.mockito.Mockito.when;
 import com.google.common.collect.ImmutableMap;
 import java.util.Arrays;
 import java.util.Collections;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.boot.actuate.health.Health;
 import org.springframework.boot.actuate.health.Status;
 
-@RunWith(MockitoJUnitRunner.StrictStubs.class)
+@ExtendWith(MockitoExtension.class)
 public class PrometheusHealthIndicatorTest {
 
   @Mock PrometheusHealthCache healthCache;
   @InjectMocks PrometheusHealthIndicator healthIndicator;
+
+  @BeforeEach
+  void setUp() {
+    MockitoAnnotations.openMocks(this);
+  }
 
   @Test
   public void downWhenHealthStatusesEmpty() {

--- a/kayenta-prometheus/src/test/java/com/netflix/kayenta/prometheus/health/PrometheusHealthJobTest.java
+++ b/kayenta-prometheus/src/test/java/com/netflix/kayenta/prometheus/health/PrometheusHealthJobTest.java
@@ -26,15 +26,16 @@ import com.netflix.kayenta.retrofit.config.RemoteService;
 import com.netflix.kayenta.security.AccountCredentialsRepository;
 import java.util.Arrays;
 import java.util.Optional;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.boot.actuate.health.Status;
 
-@RunWith(MockitoJUnitRunner.StrictStubs.class)
+@ExtendWith(MockitoExtension.class)
 public class PrometheusHealthJobTest {
 
   private static final String PROM_ACCOUNT_1 = "a1";
@@ -48,8 +49,9 @@ public class PrometheusHealthJobTest {
 
   @InjectMocks PrometheusHealthJob healthJob;
 
-  @Before
+  @BeforeEach
   public void setUp() {
+    MockitoAnnotations.openMocks(this);
     when(prometheusConfigurationProperties.getAccounts())
         .thenReturn(
             Arrays.asList(

--- a/kayenta-prometheus/src/test/java/com/netflix/kayenta/prometheus/integration/CanaryAnalysisPrometheusMetricsMixerServiceIntegrationTest.java
+++ b/kayenta-prometheus/src/test/java/com/netflix/kayenta/prometheus/integration/CanaryAnalysisPrometheusMetricsMixerServiceIntegrationTest.java
@@ -22,8 +22,8 @@ import com.netflix.kayenta.security.AccountCredentialsRepository;
 import com.netflix.spectator.api.NoopRegistry;
 import java.time.Instant;
 import java.util.List;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import retrofit.mime.TypedByteArray;
 import retrofit.mime.TypedInput;
@@ -48,7 +48,7 @@ public class CanaryAnalysisPrometheusMetricsMixerServiceIntegrationTest {
 
   private MetricSetMixerService metricSetMixerService;
 
-  @Before
+  @BeforeEach
   public void before() {
     initMocks(this);
     prometheusResponseConverter = new PrometheusResponseConverter(new ObjectMapper());

--- a/kayenta-prometheus/src/test/java/com/netflix/kayenta/prometheus/metrics/PrometheusMetricDescriptorsCacheTest.java
+++ b/kayenta-prometheus/src/test/java/com/netflix/kayenta/prometheus/metrics/PrometheusMetricDescriptorsCacheTest.java
@@ -30,13 +30,15 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class PrometheusMetricDescriptorsCacheTest {
 
   private static final String ACCOUNT_1 = "metrics-acc-1";
@@ -47,6 +49,11 @@ public class PrometheusMetricDescriptorsCacheTest {
   @Mock AccountCredentialsRepository accountCredentialRepo;
 
   @InjectMocks PrometheusMetricDescriptorsCache cache;
+
+  @BeforeEach
+  void setUp() {
+    MockitoAnnotations.openMocks(this);
+  }
 
   @Test
   public void returnsEmptyMapIfNoDataForEmptyFilter() {

--- a/kayenta-prometheus/src/test/java/com/netflix/kayenta/prometheus/service/PrometheusRemoteServiceTest.java
+++ b/kayenta-prometheus/src/test/java/com/netflix/kayenta/prometheus/service/PrometheusRemoteServiceTest.java
@@ -36,9 +36,9 @@ import java.util.List;
 import java.util.Scanner;
 import lombok.SneakyThrows;
 import org.apache.commons.lang3.StringUtils;
-import org.junit.Before;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockserver.client.MockServerClient;
 import org.mockserver.junit.MockServerRule;
 import org.mockserver.model.MediaType;
@@ -55,7 +55,7 @@ public class PrometheusRemoteServiceTest {
   OkHttpClient okHttpClient = new OkHttpClient();
   PrometheusRemoteService prometheusRemoteService;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     prometheusRemoteService = createClient(mockServerClient.getPort());
   }

--- a/kayenta-signalfx/kayenta-signalfx.gradle
+++ b/kayenta-signalfx/kayenta-signalfx.gradle
@@ -133,4 +133,5 @@ test {
   testLogging {
     events "passed", "skipped", "failed"
   }
+  useJUnitPlatform()
 }

--- a/kayenta-signalfx/src/integration-test/java/com/netflix/kayenta/signalfx/BaseSignalFxIntegrationTest.java
+++ b/kayenta-signalfx/src/integration-test/java/com/netflix/kayenta/signalfx/BaseSignalFxIntegrationTest.java
@@ -22,14 +22,14 @@ import com.netflix.kayenta.canary.CanaryConfig;
 import java.io.IOException;
 import java.time.Instant;
 import lombok.extern.slf4j.Slf4j;
-import org.junit.Before;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.web.server.LocalServerPort;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = Main.class)
 @Slf4j
 public abstract class BaseSignalFxIntegrationTest {
@@ -55,7 +55,7 @@ public abstract class BaseSignalFxIntegrationTest {
     return "http://localhost:" + serverPort + "%s";
   }
 
-  @Before
+  @BeforeEach
   public void before() {
     try {
       integrationTestCanaryConfig =

--- a/kayenta-signalfx/src/integration-test/java/com/netflix/kayenta/signalfx/EndToEndCanaryIntegrationTests.java
+++ b/kayenta-signalfx/src/integration-test/java/com/netflix/kayenta/signalfx/EndToEndCanaryIntegrationTests.java
@@ -34,8 +34,8 @@ import io.restassured.response.ValidatableResponse;
 import java.io.IOException;
 import java.time.Instant;
 import lombok.extern.slf4j.Slf4j;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /** End to end integration tests */
 @Slf4j
@@ -43,7 +43,7 @@ public class EndToEndCanaryIntegrationTests extends BaseSignalFxIntegrationTest 
 
   public static final int CANARY_WINDOW_IN_MINUTES = 5;
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeClass() {
     System.setProperty("block.for.metrics", System.getProperty("block.for.metrics", "true"));
   }

--- a/kayenta-signalfx/src/integration-test/java/com/netflix/kayenta/signalfx/EndToEndStandaloneCanaryAnalysisIntegrationTests.java
+++ b/kayenta-signalfx/src/integration-test/java/com/netflix/kayenta/signalfx/EndToEndStandaloneCanaryAnalysisIntegrationTests.java
@@ -31,13 +31,13 @@ import com.netflix.kayenta.standalonecanaryanalysis.domain.CanaryAnalysisExecuti
 import com.netflix.kayenta.standalonecanaryanalysis.domain.StageMetadata;
 import io.restassured.response.ValidatableResponse;
 import lombok.extern.slf4j.Slf4j;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 @Slf4j
 public class EndToEndStandaloneCanaryAnalysisIntegrationTests extends BaseSignalFxIntegrationTest {
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeClass() {
     System.setProperty("block.for.metrics", System.getProperty("block.for.metrics", "false"));
   }

--- a/kayenta-signalfx/src/test/java/com/netflix/kayenta/signalfx/metrics/SignalFxQueryBuilderServiceTest.java
+++ b/kayenta-signalfx/src/test/java/com/netflix/kayenta/signalfx/metrics/SignalFxQueryBuilderServiceTest.java
@@ -25,14 +25,14 @@ import com.netflix.kayenta.canary.CanaryScope;
 import com.netflix.kayenta.canary.providers.metrics.SignalFxCanaryMetricSetQueryConfig;
 import com.netflix.kayenta.signalfx.canary.SignalFxCanaryScope;
 import com.netflix.kayenta.signalfx.config.SignalFxScopeConfiguration;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class SignalFxQueryBuilderServiceTest {
 
   private SignalFxQueryBuilderService signalFxQueryBuilderService;
 
-  @Before
+  @BeforeEach
   public void before() {
     signalFxQueryBuilderService = new SignalFxQueryBuilderService();
   }

--- a/kayenta-signalfx/src/test/java/com/netflix/kayenta/signalfx/metrics/SimpleSignalFlowProgramBuilderTest.java
+++ b/kayenta-signalfx/src/test/java/com/netflix/kayenta/signalfx/metrics/SimpleSignalFlowProgramBuilderTest.java
@@ -26,7 +26,7 @@ import com.netflix.kayenta.signalfx.config.SignalFxScopeConfiguration;
 import com.tngtech.java.junit.dataprovider.DataProvider;
 import com.tngtech.java.junit.dataprovider.DataProviderRunner;
 import com.tngtech.java.junit.dataprovider.UseDataProvider;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
 
 @RunWith(DataProviderRunner.class)

--- a/kayenta-signalfx/src/test/java/com/netflix/kayenta/signalfx/service/SignalFxRemoteServiceTest.java
+++ b/kayenta-signalfx/src/test/java/com/netflix/kayenta/signalfx/service/SignalFxRemoteServiceTest.java
@@ -23,7 +23,7 @@ import static org.junit.Assert.assertThat;
 
 import com.google.common.io.ByteStreams;
 import java.io.InputStream;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import retrofit.mime.TypedByteArray;
 import retrofit.mime.TypedInput;
 

--- a/kayenta-sql/src/test/java/com/netflix/kayenta/sql/storage/SqlStorageServiceTest.java
+++ b/kayenta-sql/src/test/java/com/netflix/kayenta/sql/storage/SqlStorageServiceTest.java
@@ -40,15 +40,15 @@ import com.netflix.spinnaker.kork.web.exceptions.NotFoundException;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.*;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Bean;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 public class SqlStorageServiceTest {
 
   private static ObjectMapper objectMapper =

--- a/kayenta-stackdriver/kayenta-stackdriver.gradle
+++ b/kayenta-stackdriver/kayenta-stackdriver.gradle
@@ -3,3 +3,6 @@ dependencies {
   implementation project(":kayenta-google")
   api "com.google.apis:google-api-services-monitoring"
 }
+test {
+  useJUnitPlatform()
+}

--- a/kayenta-standalone-canary-analysis/src/test/java/com/netflix/kayenta/standalonecanaryanalysis/orca/stage/SetupAndExecuteCanariesStageTest.java
+++ b/kayenta-standalone-canary-analysis/src/test/java/com/netflix/kayenta/standalonecanaryanalysis/orca/stage/SetupAndExecuteCanariesStageTest.java
@@ -28,8 +28,8 @@ import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 
 public class SetupAndExecuteCanariesStageTest {
@@ -40,7 +40,7 @@ public class SetupAndExecuteCanariesStageTest {
 
   private Instant now = Instant.now();
 
-  @Before
+  @BeforeEach
   public void before() {
     initMocks(this);
 

--- a/kayenta-standalone-canary-analysis/src/test/java/com/netflix/kayenta/standalonecanaryanalysis/orca/task/GenerateCanaryAnalysisResultTaskTest.java
+++ b/kayenta-standalone-canary-analysis/src/test/java/com/netflix/kayenta/standalonecanaryanalysis/orca/task/GenerateCanaryAnalysisResultTaskTest.java
@@ -32,8 +32,8 @@ import com.tngtech.java.junit.dataprovider.DataProvider;
 import com.tngtech.java.junit.dataprovider.DataProviderRunner;
 import com.tngtech.java.junit.dataprovider.UseDataProvider;
 import java.util.List;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
 
 @RunWith(DataProviderRunner.class)
@@ -53,7 +53,7 @@ public class GenerateCanaryAnalysisResultTaskTest {
     };
   }
 
-  @Before
+  @BeforeEach
   public void before() {
     task = new GenerateCanaryAnalysisResultTask(new ObjectMapper());
   }

--- a/kayenta-wavefront/src/test/java/com/netflix/kayenta/wavefront/canary/WavefrontCanaryScopeFactoryTest.java
+++ b/kayenta-wavefront/src/test/java/com/netflix/kayenta/wavefront/canary/WavefrontCanaryScopeFactoryTest.java
@@ -20,7 +20,7 @@ import static org.junit.Assert.assertThat;
 
 import com.netflix.kayenta.canary.CanaryScope;
 import java.time.Instant;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class WavefrontCanaryScopeFactoryTest {
 

--- a/kayenta-wavefront/src/test/java/com/netflix/kayenta/wavefront/metrics/WavefrontMetricsServiceTest.java
+++ b/kayenta-wavefront/src/test/java/com/netflix/kayenta/wavefront/metrics/WavefrontMetricsServiceTest.java
@@ -22,7 +22,7 @@ import com.netflix.kayenta.canary.CanaryMetricConfig;
 import com.netflix.kayenta.canary.CanaryScope;
 import com.netflix.kayenta.canary.providers.metrics.WavefrontCanaryMetricSetQueryConfig;
 import com.netflix.kayenta.wavefront.canary.WavefrontCanaryScope;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class WavefrontMetricsServiceTest {
 

--- a/kayenta-wavefront/src/test/java/com/netflix/kayenta/wavefront/service/WavefrontTimeSeriesTest.java
+++ b/kayenta-wavefront/src/test/java/com/netflix/kayenta/wavefront/service/WavefrontTimeSeriesTest.java
@@ -21,7 +21,7 @@ import static org.junit.Assert.assertThat;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class WavefrontTimeSeriesTest {
 

--- a/kayenta-web/kayenta-web.gradle
+++ b/kayenta-web/kayenta-web.gradle
@@ -38,3 +38,6 @@ dependencies {
   runtimeOnly "io.spinnaker.kork:kork-secrets-aws"
   runtimeOnly "io.spinnaker.kork:kork-secrets-gcp"
 }
+test {
+  useJUnitPlatform()
+}

--- a/kayenta-web/src/test/java/com/netflix/kayenta/controllers/BaseControllerTest.java
+++ b/kayenta-web/src/test/java/com/netflix/kayenta/controllers/BaseControllerTest.java
@@ -22,8 +22,8 @@ import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import org.junit.Before;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Answers;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -32,7 +32,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Scope;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
@@ -41,7 +41,7 @@ import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 @SpringBootTest(
     classes = BaseControllerTest.TestControllersConfiguration.class,
     webEnvironment = SpringBootTest.WebEnvironment.MOCK)
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 public abstract class BaseControllerTest {
 
   protected static final String CONFIGS_ACCOUNT = "configs-account";
@@ -65,7 +65,7 @@ public abstract class BaseControllerTest {
 
   protected MockMvc mockMvc;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     this.mockMvc =
         MockMvcBuilders.webAppContextSetup(this.webApplicationContext).alwaysDo(print()).build();

--- a/kayenta-web/src/test/java/com/netflix/kayenta/controllers/CanaryConfigControllerTest.java
+++ b/kayenta-web/src/test/java/com/netflix/kayenta/controllers/CanaryConfigControllerTest.java
@@ -15,7 +15,7 @@ import com.netflix.kayenta.storage.ObjectType;
 import com.netflix.spinnaker.kork.web.exceptions.NotFoundException;
 import java.io.InputStream;
 import org.apache.commons.io.IOUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class CanaryConfigControllerTest extends BaseControllerTest {
 

--- a/kayenta-web/src/test/java/com/netflix/kayenta/controllers/CanaryControllerTest.java
+++ b/kayenta-web/src/test/java/com/netflix/kayenta/controllers/CanaryControllerTest.java
@@ -7,7 +7,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.netflix.kayenta.canary.CanaryConfig;
 import com.netflix.kayenta.storage.ObjectType;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class CanaryControllerTest extends BaseControllerTest {
 


### PR DESCRIPTION
## Summary
**Project Jira :** [Ref](https://devopsmx.atlassian.net/browse/OP-20720)
**Project Doc :** [Ref](https://docs.google.com/spreadsheets/d/1bWOLaL3F_Fbe6P6CUyZJOqzMhWxw1j-Sl-9zE0pBtWw/edit#gid=1074720956)

**Feature :** Code changes to support Junit5 (removed Junit4 support)
**Issue wrt commit:[Fixed Parameterized Tests in kayenta-blobs](https://github.com/OpsMx/kayenta-oes/pull/12/commits/377fb6f9c8306368df53863ebc456b94ff2c6c8d):** TC failing in TestableBlobsStorageServiceTest
->  org.junit.jupiter.api.extension.ParameterResolutionException: No ParameterResolver registered for parameter [java.lang.String arg0] in method [public void com.netflix.kayenta.blobs.storage.TestableBlobsStorageServiceTest.deleteObject(java.lang.String,com.netflix.kayenta.storage.ObjectType,java.lang.String)]
**Solution :** Code changes to support Junit5 -> replace @Test & @UseDataProvider with @ParameterizedTest and @MethodSource [Ref](https://www.baeldung.com/parameterized-tests-junit-5)

### How changes are verified
List of passing/failing TCs : [Ref](https://docs.google.com/spreadsheets/d/1bWOLaL3F_Fbe6P6CUyZJOqzMhWxw1j-Sl-9zE0pBtWw/edit#gid=1074720956)
wrt kayenta-blobs : all TCs are passing now

## Documentation Updates
Do we need to update dashboards? No
Do we need to update SOP, new hire wiki or other documents? No

## Rollback, Deployment Details
Can this change be rolled back automatically without any issue?  Yes
Is this a backwards-compatible change in your opinion ?  Yes
**Pre deployment steps :** NA
**Post deployment steps :** NA