### PR TITLE
OP-21877 Upgraded signalfx-java version

### DIFF
--- a/kayenta-signalfx/kayenta-signalfx.gradle
+++ b/kayenta-signalfx/kayenta-signalfx.gradle
@@ -109,7 +109,7 @@ integrationTest {
 dependencies {
   implementation project(":kayenta-core")
 
-  api 'com.signalfx.public:signalfx-java:1.0.31'
+  implementation 'com.signalfx.public:signalfx-java:1.0.39'
 
   testImplementation 'com.tngtech.java:junit-dataprovider:1.13.1'
   testImplementation project(":kayenta-standalone-canary-analysis")


### PR DESCRIPTION
**Jira** : https://devopsmx.atlassian.net/browse/OP-21877
**Summary** : 
google-guava:31.0.0 is coming from signalfx-java [ref](https://docs.google.com/spreadsheets/d/1bdJhyf7VI8akDsPhqCO38NgQ0_l9rRI-CaecPMsEC_Q/edit#gid=393237493)
1. Fixed by upgrading signal-fx to latest version.
2. Didnt see any reason for having api(), so replaced with implementation. But OSS has api() [ref](https://github.com/spinnaker/kayenta/blob/827008cae996957338b9edb98dafa7e09ebda3b7/kayenta-signalfx/kayenta-signalfx.gradle#L112)
3. This dependency is not coming from kork, so hardcoded the version in kayenta-signalfx-build.gradle itself

**Testing**:
No new TCs fail bcoz of this change, compile success, service is getting started.
cve not found on local trivy scan on aman1603/kayenta:14march13